### PR TITLE
Renaming to Claimer

### DIFF
--- a/flattened/TweedentityClaimer-flattened.sol
+++ b/flattened/TweedentityClaimer-flattened.sol
@@ -2014,21 +2014,20 @@ contract TweedentityManager is AuthorizableLite, TweedentityManagerInterfaceComp
 
 }
 
-// File: contracts/TweedentityVerifier.sol
+// File: contracts/TweedentityClaimer.sol
 
-contract TweedentityVerifier is usingOraclize, Ownable {
+contract TweedentityClaimer is usingOraclize, Ownable {
 
   uint public version = 1;
 
   event VerificationStarted(
+    bytes32 oraclizeId,
     address addr,
     string appNickname,
-    string postId,
-    bytes32 oraclizeId
+    string postId
   );
 
   event VerificatioFailed(
-    address addr,
     bytes32 oraclizeId
   );
 
@@ -2039,7 +2038,7 @@ contract TweedentityVerifier is usingOraclize, Ownable {
 
   struct TempData {
     address sender;
-    string appNickname;
+    uint appId;
   }
 
   mapping(bytes32 => TempData) internal __tempData;
@@ -2063,7 +2062,7 @@ contract TweedentityVerifier is usingOraclize, Ownable {
   }
 
   // Verifies that the signature published on twitter is correct
-  function verifyAccountOwnership(
+  function claimOwnership(
     string _appNickname,
     string _pathname,
     uint _gasPrice,
@@ -2091,8 +2090,8 @@ contract TweedentityVerifier is usingOraclize, Ownable {
       __concat(str),
       _gasLimit
     );
-    VerificationStarted(msg.sender, _appNickname, _pathname, oraclizeID);
-    __tempData[oraclizeID] = TempData(msg.sender, _appNickname);
+    VerificationStarted(oraclizeID, msg.sender, _appNickname, _pathname);
+    __tempData[oraclizeID] = TempData(msg.sender, manager.getAppId(_appNickname));
   }
 
 
@@ -2105,9 +2104,9 @@ contract TweedentityVerifier is usingOraclize, Ownable {
   {
     require(msg.sender == oraclize_cbAddress());
     if (bytes(_result).length > 0) {
-      manager.setIdentity(manager.getAppId(__tempData[_oraclizeID].appNickname), __tempData[_oraclizeID].sender, _result);
+      manager.setIdentity(__tempData[_oraclizeID].appId, __tempData[_oraclizeID].sender, _result);
     } else {
-      VerificatioFailed(__tempData[_oraclizeID].sender, _oraclizeID);
+      VerificatioFailed(_oraclizeID);
     }
   }
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,9 +1,9 @@
 var TweedentityStore = artifacts.require("./TweedentityStore")
 var TweedentityManager = artifacts.require("./TweedentityManager")
-var TweedentityVerifier = artifacts.require("./TweedentityVerifier")
+var TweedentityClaimer = artifacts.require("./TweedentityClaimer")
 
 module.exports = function(deployer) {
-  deployer.deploy(TweedentityStore)
-  deployer.deploy(TweedentityManager)
-  deployer.deploy(TweedentityVerifier)
+  // deployer.deploy(TweedentityStore)
+  // deployer.deploy(TweedentityManager)
+  deployer.deploy(TweedentityClaimer)
 }

--- a/scripts/flatten.sh
+++ b/scripts/flatten.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
+rm flattened/*
+
 contracts=(
 "TweedentityStore"
 "TweedentityManager"
-"TweedentityVerifier"
+"TweedentityClaimer"
 )
 
 for c in "${contracts[@]}"

--- a/test/TweedentityStore-test.js
+++ b/test/TweedentityStore-test.js
@@ -1,5 +1,5 @@
-const assertRevert = require('./helpers/assertRevert')
 const log = require('./helpers/log')
+const assertRevert = require('./helpers/assertRevert')
 
 const eventWatcher = require('./helpers/EventWatcher')
 

--- a/test/helpers/EventWatcher.js
+++ b/test/helpers/EventWatcher.js
@@ -16,8 +16,10 @@ class EventWatcher {
   }
 
   stop() {
-    this.event.stopWatching()
-    this.event = null
+    if (this.event) {
+      this.event.stopWatching()
+      this.event = null
+    }
   }
 }
 


### PR DESCRIPTION
Renaming Verifier to Claimer which makes more sense because the contract allows the user to claim her ownership of a certain account.