### PR TITLE
Using HasNoEther instead of Ownable

### DIFF
--- a/contracts/TweedentityClaimer.sol
+++ b/contracts/TweedentityClaimer.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.18;
 
 
 import '../ethereum-api/oraclizeAPI_0.5.sol';
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/ownership/HasNoEther.sol';
 
 import './TweedentityManager.sol';
 
@@ -17,7 +17,7 @@ import './TweedentityManager.sol';
 
 
 contract TweedentityClaimer /** 1.0.2 */
-is usingOraclize, Ownable
+is usingOraclize, HasNoEther
 {
 
   string public apiUrl = "https://api.tweedentity.net/";
@@ -99,7 +99,7 @@ is usingOraclize, Ownable
   payable
   {
     require(bytes(_postId).length > 0);
-    require(msg.value == _gasPrice * _gasLimit);
+    require(msg.value >= _gasPrice * _gasLimit);
 
     oraclize_setCustomGasPrice(_gasPrice);
 

--- a/contracts/TweedentityManager.sol
+++ b/contracts/TweedentityManager.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 
 import 'openzeppelin-solidity/contracts/lifecycle/Pausable.sol';
+import 'openzeppelin-solidity/contracts/ownership/HasNoEther.sol';
 
 import './TweedentityStore.sol';
 
@@ -15,7 +16,7 @@ import './TweedentityStore.sol';
 
 
 contract TweedentityManager /** 1.0.2 */
-is Pausable
+is Pausable, HasNoEther
 {
 
   struct Store {

--- a/contracts/TweedentityRegistry.sol
+++ b/contracts/TweedentityRegistry.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.18;
 
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/ownership/HasNoEther.sol';
 
 
 contract Pausable {
@@ -18,7 +18,7 @@ contract Pausable {
 
 
 contract TweedentityRegistry  /** 1.0.2 */
-is Ownable
+is HasNoEther
 {
 
   uint public totalStores;

--- a/contracts/TweedentityStore.sol
+++ b/contracts/TweedentityStore.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.18;
 
 
-import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'openzeppelin-solidity/contracts/ownership/HasNoEther.sol';
 
 
 
@@ -14,7 +14,7 @@ import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
 
 contract TweedentityStore /** 1.0.2 */
-is Ownable
+is HasNoEther
 {
 
   uint public appId;

--- a/flattened/TweedentityClaimer-flattened.sol
+++ b/flattened/TweedentityClaimer-flattened.sol
@@ -1264,6 +1264,45 @@ contract Ownable {
 
 }
 
+// File: openzeppelin-solidity/contracts/ownership/HasNoEther.sol
+
+/**
+ * @title Contracts that should not own Ether
+ * @author Remco Bloemen <remco@2π.com>
+ * @dev This tries to block incoming ether to prevent accidental loss of Ether. Should Ether end up
+ * in the contract, it will allow the owner to reclaim this ether.
+ * @notice Ether can still be send to this contract by:
+ * calling functions labeled `payable`
+ * `selfdestruct(contract_address)`
+ * mining directly to the contract address
+*/
+contract HasNoEther is Ownable {
+
+  /**
+  * @dev Constructor that rejects incoming Ether
+  * @dev The `payable` flag is added so we can access `msg.value` without compiler warning. If we
+  * leave out payable, then Solidity will allow inheriting contracts to implement a payable
+  * constructor. By doing it this way we prevent a payable constructor from working. Alternatively
+  * we could use assembly to access msg.value.
+  */
+  function HasNoEther() public payable {
+    require(msg.value == 0);
+  }
+
+  /**
+   * @dev Disallows direct send by settings a default function without the `payable` flag.
+   */
+  function() external {
+  }
+
+  /**
+   * @dev Transfer all Ether held by the contract to the owner.
+   */
+  function reclaimEther() external onlyOwner {
+    assert(owner.send(this.balance));
+  }
+}
+
 // File: contracts/TweedentityStore.sol
 
 /**
@@ -1275,7 +1314,7 @@ contract Ownable {
 
 
 contract TweedentityStore /** 1.0.2 */
-is Ownable
+is HasNoEther
 {
 
   uint public appId;
@@ -1695,7 +1734,7 @@ contract Pausable is Ownable {
 
 
 contract TweedentityManager /** 1.0.2 */
-is Pausable
+is Pausable, HasNoEther
 {
 
   struct Store {
@@ -2110,7 +2149,7 @@ is Pausable
 
 
 contract TweedentityClaimer /** 1.0.2 */
-is usingOraclize, Ownable
+is usingOraclize, HasNoEther
 {
 
   string public apiUrl = "https://api.tweedentity.net/";
@@ -2192,7 +2231,7 @@ is usingOraclize, Ownable
   payable
   {
     require(bytes(_postId).length > 0);
-    require(msg.value == _gasPrice * _gasLimit);
+    require(msg.value >= _gasPrice * _gasLimit);
 
     oraclize_setCustomGasPrice(_gasPrice);
 

--- a/flattened/TweedentityManager-flattened.sol
+++ b/flattened/TweedentityManager-flattened.sol
@@ -42,6 +42,45 @@ contract Ownable {
 
 }
 
+// File: openzeppelin-solidity/contracts/ownership/HasNoEther.sol
+
+/**
+ * @title Contracts that should not own Ether
+ * @author Remco Bloemen <remco@2π.com>
+ * @dev This tries to block incoming ether to prevent accidental loss of Ether. Should Ether end up
+ * in the contract, it will allow the owner to reclaim this ether.
+ * @notice Ether can still be send to this contract by:
+ * calling functions labeled `payable`
+ * `selfdestruct(contract_address)`
+ * mining directly to the contract address
+*/
+contract HasNoEther is Ownable {
+
+  /**
+  * @dev Constructor that rejects incoming Ether
+  * @dev The `payable` flag is added so we can access `msg.value` without compiler warning. If we
+  * leave out payable, then Solidity will allow inheriting contracts to implement a payable
+  * constructor. By doing it this way we prevent a payable constructor from working. Alternatively
+  * we could use assembly to access msg.value.
+  */
+  function HasNoEther() public payable {
+    require(msg.value == 0);
+  }
+
+  /**
+   * @dev Disallows direct send by settings a default function without the `payable` flag.
+   */
+  function() external {
+  }
+
+  /**
+   * @dev Transfer all Ether held by the contract to the owner.
+   */
+  function reclaimEther() external onlyOwner {
+    assert(owner.send(this.balance));
+  }
+}
+
 // File: contracts/TweedentityStore.sol
 
 /**
@@ -53,7 +92,7 @@ contract Ownable {
 
 
 contract TweedentityStore /** 1.0.2 */
-is Ownable
+is HasNoEther
 {
 
   uint public appId;
@@ -473,7 +512,7 @@ contract Pausable is Ownable {
 
 
 contract TweedentityManager /** 1.0.2 */
-is Pausable
+is Pausable, HasNoEther
 {
 
   struct Store {

--- a/flattened/TweedentityRegistry-flattened.sol
+++ b/flattened/TweedentityRegistry-flattened.sol
@@ -42,6 +42,45 @@ contract Ownable {
 
 }
 
+// File: openzeppelin-solidity/contracts/ownership/HasNoEther.sol
+
+/**
+ * @title Contracts that should not own Ether
+ * @author Remco Bloemen <remco@2π.com>
+ * @dev This tries to block incoming ether to prevent accidental loss of Ether. Should Ether end up
+ * in the contract, it will allow the owner to reclaim this ether.
+ * @notice Ether can still be send to this contract by:
+ * calling functions labeled `payable`
+ * `selfdestruct(contract_address)`
+ * mining directly to the contract address
+*/
+contract HasNoEther is Ownable {
+
+  /**
+  * @dev Constructor that rejects incoming Ether
+  * @dev The `payable` flag is added so we can access `msg.value` without compiler warning. If we
+  * leave out payable, then Solidity will allow inheriting contracts to implement a payable
+  * constructor. By doing it this way we prevent a payable constructor from working. Alternatively
+  * we could use assembly to access msg.value.
+  */
+  function HasNoEther() public payable {
+    require(msg.value == 0);
+  }
+
+  /**
+   * @dev Disallows direct send by settings a default function without the `payable` flag.
+   */
+  function() external {
+  }
+
+  /**
+   * @dev Transfer all Ether held by the contract to the owner.
+   */
+  function reclaimEther() external onlyOwner {
+    assert(owner.send(this.balance));
+  }
+}
+
 // File: contracts/TweedentityRegistry.sol
 
 contract Pausable {
@@ -58,7 +97,7 @@ contract Pausable {
 
 
 contract TweedentityRegistry  /** 1.0.2 */
-is Ownable
+is HasNoEther
 {
 
   uint public totalStores;

--- a/flattened/TweedentityStore-flattened.sol
+++ b/flattened/TweedentityStore-flattened.sol
@@ -42,6 +42,45 @@ contract Ownable {
 
 }
 
+// File: openzeppelin-solidity/contracts/ownership/HasNoEther.sol
+
+/**
+ * @title Contracts that should not own Ether
+ * @author Remco Bloemen <remco@2π.com>
+ * @dev This tries to block incoming ether to prevent accidental loss of Ether. Should Ether end up
+ * in the contract, it will allow the owner to reclaim this ether.
+ * @notice Ether can still be send to this contract by:
+ * calling functions labeled `payable`
+ * `selfdestruct(contract_address)`
+ * mining directly to the contract address
+*/
+contract HasNoEther is Ownable {
+
+  /**
+  * @dev Constructor that rejects incoming Ether
+  * @dev The `payable` flag is added so we can access `msg.value` without compiler warning. If we
+  * leave out payable, then Solidity will allow inheriting contracts to implement a payable
+  * constructor. By doing it this way we prevent a payable constructor from working. Alternatively
+  * we could use assembly to access msg.value.
+  */
+  function HasNoEther() public payable {
+    require(msg.value == 0);
+  }
+
+  /**
+   * @dev Disallows direct send by settings a default function without the `payable` flag.
+   */
+  function() external {
+  }
+
+  /**
+   * @dev Transfer all Ether held by the contract to the owner.
+   */
+  function reclaimEther() external onlyOwner {
+    assert(owner.send(this.balance));
+  }
+}
+
 // File: contracts/TweedentityStore.sol
 
 /**
@@ -53,7 +92,7 @@ contract Ownable {
 
 
 contract TweedentityStore /** 1.0.2 */
-is Ownable
+is HasNoEther
 {
 
   uint public appId;


### PR DESCRIPTION
Using HasNoEther instead of Ownable to avoid involuntary payment, and recover lost ether