### PR TITLE
Separating checker

### DIFF
--- a/contracts/RedditUidChecker.sol
+++ b/contracts/RedditUidChecker.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.4.18;
+
+
+/**
+ * @title RedditUidChecker
+ * @author Francesco Sullo <francesco@sullo.co>
+ * @dev Checks if a uid is a Reddit uid
+ */
+
+
+
+contract RedditUidChecker
+{
+
+  string public version = "1.5.0";
+
+  function isUid(
+    string _uid
+  )
+  public
+  pure
+  returns (bool)
+  {
+    bytes memory uid = bytes(_uid);
+    if (uid.length < 3 || uid.length > 20) {
+      return false;
+    } else {
+      for (uint i = 0; i < uid.length; i++) {
+        if (!(
+        uid[i] == 45 || uid[i] == 95
+        || (uid[i] >= 48 && uid[i] <= 57)
+        // it requires lowercases, to avoid conflicts
+        // even if Reddit allows lower and upper cases
+        || (uid[i] >= 97 && uid[i] <= 122)
+        )) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+}

--- a/contracts/TweedentityManager.sol
+++ b/contracts/TweedentityManager.sol
@@ -19,7 +19,7 @@ contract TweedentityManager
 is Pausable, HasNoEther
 {
 
-  string public version = "1.3.0";
+  string public version = "1.5.0";
 
   struct Store {
     TweedentityStore store;
@@ -329,6 +329,7 @@ is Pausable, HasNoEther
 
     TweedentityStore _store = __getStore(_appId);
     require(_store.isUid(_uid));
+
     if (isUpgradable(_store, _address, _uid)) {
       _store.setIdentity(_address, _uid);
     } else {
@@ -383,41 +384,6 @@ is Pausable, HasNoEther
   onlyOwner
   {
     minimumTimeBeforeUpdate = _newMinimumTime;
-  }
-
-
-
-  // private methods
-
-
-  function __stringToUint(
-    string s
-  )
-  internal
-  pure
-  returns (uint result)
-  {
-    bytes memory b = bytes(s);
-    uint i;
-    result = 0;
-    for (i = 0; i < b.length; i++) {
-      uint c = uint(b[i]);
-      if (c >= 48 && c <= 57) {
-        result = result * 10 + (c - 48);
-      }
-    }
-  }
-
-
-  function __uintToBytes(uint x)
-  internal
-  pure
-  returns (bytes b)
-  {
-    b = new bytes(32);
-    for (uint i = 0; i < 32; i++) {
-      b[i] = byte(uint8(x / (2 ** (8 * (31 - i)))));
-    }
   }
 
 }

--- a/contracts/TweedentityStore.sol
+++ b/contracts/TweedentityStore.sol
@@ -76,7 +76,7 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet && checker != address(0));
+    require(appSet);
     _;
   }
 
@@ -157,6 +157,7 @@ is HasNoEther
   {
     require(!appSet);
     require(_appId > 0);
+    require(_checker != address(0));
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;

--- a/contracts/TwitterUidChecker.sol
+++ b/contracts/TwitterUidChecker.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.4.18;
+
+
+/**
+ * @title TwitterUidChecker
+ * @author Francesco Sullo <francesco@sullo.co>
+ * @dev Checks if a uid is a Twitter uid
+ */
+
+
+
+contract TwitterUidChecker
+{
+
+  string public version = "1.5.0";
+
+  function isUid(
+    string _uid
+  )
+  public
+  pure
+  returns (bool)
+  {
+    bytes memory uid = bytes(_uid);
+    if (uid.length == 0 || uid.length > 20) {
+      return false;
+    } else {
+      for (uint i = 0; i < uid.length; i++) {
+        if (uid[i] < 48 || uid[i] > 57) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+}

--- a/contracts/helpers/TweedentityStoreCaller.sol
+++ b/contracts/helpers/TweedentityStoreCaller.sol
@@ -20,10 +20,6 @@ contract TweedentityStoreCaller {
   // compiler with produce an error when calling any getter that
   // returns not-allowed dynamic data
 
-  function getUidAsInteger(address _address) public constant returns (uint){
-    return store.getUidAsInteger(_address);
-  }
-
   function getAddress(string _uid) public constant returns (address){
     return store.getAddress(_uid);
   }

--- a/flattened/RedditUidChecker-flattened.sol
+++ b/flattened/RedditUidChecker-flattened.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.18;
+
+// File: contracts/RedditUidChecker.sol
+
+/**
+ * @title RedditUidChecker
+ * @author Francesco Sullo <francesco@sullo.co>
+ * @dev Checks if a uid is a Reddit uid
+ */
+
+
+
+contract RedditUidChecker
+{
+
+  string public version = "1.5.0";
+
+  function isUid(
+    string _uid
+  )
+  public
+  pure
+  returns (bool)
+  {
+    bytes memory uid = bytes(_uid);
+    if (uid.length < 3 || uid.length > 20) {
+      return false;
+    } else {
+      for (uint i = 0; i < uid.length; i++) {
+        if (!(
+        uid[i] == 45 || uid[i] == 95
+        || (uid[i] >= 48 && uid[i] <= 57)
+        // it requires lowercases, to avoid conflicts
+        // even if Reddit allows lower and upper cases
+        || (uid[i] >= 97 && uid[i] <= 122)
+        )) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+}

--- a/flattened/TweedentityClaimer-flattened.sol
+++ b/flattened/TweedentityClaimer-flattened.sol
@@ -1377,7 +1377,7 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet && checker != address(0));
+    require(appSet);
     _;
   }
 
@@ -1458,6 +1458,7 @@ is HasNoEther
   {
     require(!appSet);
     require(_appId > 0);
+    require(_checker != address(0));
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;

--- a/flattened/TweedentityClaimer-flattened.sol
+++ b/flattened/TweedentityClaimer-flattened.sol
@@ -1305,6 +1305,11 @@ contract HasNoEther is Ownable {
 
 // File: contracts/TweedentityStore.sol
 
+interface UidChecker {
+  function isUid(string _uid) public pure returns (bool);
+}
+
+
 /**
  * @title TweedentityStore
  * @author Francesco Sullo <francesco@sullo.co>
@@ -1317,7 +1322,7 @@ contract TweedentityStore
 is HasNoEther
 {
 
-  string public version = "1.3.0";
+  string public version = "1.5.0";
 
   uint public appId;
   string public appNickname;
@@ -1326,6 +1331,8 @@ is HasNoEther
 
   address public manager;
   address public newManager;
+
+  UidChecker public checker;
 
   struct Uid {
     string lastUid;
@@ -1370,13 +1377,28 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet);
+    require(appSet && checker != address(0));
     _;
   }
 
 
 
   // config
+
+
+  /**
+  * @dev Updates the checker for the store
+  * @param _address Checker's address
+  */
+  function setNewChecker(
+    address _address
+  )
+  external
+  onlyOwner
+  {
+    require(_address != address(0));
+    checker = UidChecker(_address);
+  }
 
 
   /**
@@ -1428,7 +1450,8 @@ is HasNoEther
   */
   function setApp(
     string _appNickname,
-    uint _appId
+    uint _appId,
+    address _checker
   )
   external
   onlyOwner
@@ -1438,6 +1461,7 @@ is HasNoEther
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;
+    checker = UidChecker(_checker);
     appSet = true;
   }
 
@@ -1563,20 +1587,6 @@ is HasNoEther
 
 
   /**
-   * @dev Returns the user-id associated to a wallet as a unsigned integer
-   * @param _address The address of the wallet
-   */
-  function getUidAsInteger(
-    address _address
-  )
-  external
-  constant returns (uint)
-  {
-    return __stringToUint(__uidByAddress[_address].lastUid);
-  }
-
-
-  /**
    * @dev Returns the address associated to a user-id
    * @param _uid The user-id
    */
@@ -1626,55 +1636,10 @@ is HasNoEther
     string _uid
   )
   public
-  pure
+  view
   returns (bool)
   {
-    bytes memory uid = bytes(_uid);
-    if (uid.length == 0) {
-      return false;
-    } else {
-      for (uint i = 0; i < uid.length; i++) {
-        if (uid[i] < 48 || uid[i] > 57) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-
-
-  // private methods
-
-
-  function __stringToUint(
-    string s
-  )
-  internal
-  pure
-  returns (uint result)
-  {
-    bytes memory b = bytes(s);
-    uint i;
-    result = 0;
-    for (i = 0; i < b.length; i++) {
-      uint c = uint(b[i]);
-      if (c >= 48 && c <= 57) {
-        result = result * 10 + (c - 48);
-      }
-    }
-  }
-
-
-  function __uintToBytes(uint x)
-  internal
-  pure
-  returns (bytes b)
-  {
-    b = new bytes(32);
-    for (uint i = 0; i < 32; i++) {
-      b[i] = byte(uint8(x / (2 ** (8 * (31 - i)))));
-    }
+    return checker.isUid(_uid);
   }
 
 }
@@ -1739,7 +1704,7 @@ contract TweedentityManager
 is Pausable, HasNoEther
 {
 
-  string public version = "1.3.0";
+  string public version = "1.5.0";
 
   struct Store {
     TweedentityStore store;
@@ -2049,6 +2014,7 @@ is Pausable, HasNoEther
 
     TweedentityStore _store = __getStore(_appId);
     require(_store.isUid(_uid));
+
     if (isUpgradable(_store, _address, _uid)) {
       _store.setIdentity(_address, _uid);
     } else {
@@ -2103,41 +2069,6 @@ is Pausable, HasNoEther
   onlyOwner
   {
     minimumTimeBeforeUpdate = _newMinimumTime;
-  }
-
-
-
-  // private methods
-
-
-  function __stringToUint(
-    string s
-  )
-  internal
-  pure
-  returns (uint result)
-  {
-    bytes memory b = bytes(s);
-    uint i;
-    result = 0;
-    for (i = 0; i < b.length; i++) {
-      uint c = uint(b[i]);
-      if (c >= 48 && c <= 57) {
-        result = result * 10 + (c - 48);
-      }
-    }
-  }
-
-
-  function __uintToBytes(uint x)
-  internal
-  pure
-  returns (bytes b)
-  {
-    b = new bytes(32);
-    for (uint i = 0; i < 32; i++) {
-      b[i] = byte(uint8(x / (2 ** (8 * (31 - i)))));
-    }
   }
 
 }

--- a/flattened/TweedentityManager-flattened.sol
+++ b/flattened/TweedentityManager-flattened.sol
@@ -155,7 +155,7 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet && checker != address(0));
+    require(appSet);
     _;
   }
 
@@ -236,6 +236,7 @@ is HasNoEther
   {
     require(!appSet);
     require(_appId > 0);
+    require(_checker != address(0));
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;

--- a/flattened/TweedentityManager-flattened.sol
+++ b/flattened/TweedentityManager-flattened.sol
@@ -83,6 +83,11 @@ contract HasNoEther is Ownable {
 
 // File: contracts/TweedentityStore.sol
 
+interface UidChecker {
+  function isUid(string _uid) public pure returns (bool);
+}
+
+
 /**
  * @title TweedentityStore
  * @author Francesco Sullo <francesco@sullo.co>
@@ -95,7 +100,7 @@ contract TweedentityStore
 is HasNoEther
 {
 
-  string public version = "1.3.0";
+  string public version = "1.5.0";
 
   uint public appId;
   string public appNickname;
@@ -104,6 +109,8 @@ is HasNoEther
 
   address public manager;
   address public newManager;
+
+  UidChecker public checker;
 
   struct Uid {
     string lastUid;
@@ -148,13 +155,28 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet);
+    require(appSet && checker != address(0));
     _;
   }
 
 
 
   // config
+
+
+  /**
+  * @dev Updates the checker for the store
+  * @param _address Checker's address
+  */
+  function setNewChecker(
+    address _address
+  )
+  external
+  onlyOwner
+  {
+    require(_address != address(0));
+    checker = UidChecker(_address);
+  }
 
 
   /**
@@ -206,7 +228,8 @@ is HasNoEther
   */
   function setApp(
     string _appNickname,
-    uint _appId
+    uint _appId,
+    address _checker
   )
   external
   onlyOwner
@@ -216,6 +239,7 @@ is HasNoEther
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;
+    checker = UidChecker(_checker);
     appSet = true;
   }
 
@@ -341,20 +365,6 @@ is HasNoEther
 
 
   /**
-   * @dev Returns the user-id associated to a wallet as a unsigned integer
-   * @param _address The address of the wallet
-   */
-  function getUidAsInteger(
-    address _address
-  )
-  external
-  constant returns (uint)
-  {
-    return __stringToUint(__uidByAddress[_address].lastUid);
-  }
-
-
-  /**
    * @dev Returns the address associated to a user-id
    * @param _uid The user-id
    */
@@ -404,55 +414,10 @@ is HasNoEther
     string _uid
   )
   public
-  pure
+  view
   returns (bool)
   {
-    bytes memory uid = bytes(_uid);
-    if (uid.length == 0) {
-      return false;
-    } else {
-      for (uint i = 0; i < uid.length; i++) {
-        if (uid[i] < 48 || uid[i] > 57) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-
-
-  // private methods
-
-
-  function __stringToUint(
-    string s
-  )
-  internal
-  pure
-  returns (uint result)
-  {
-    bytes memory b = bytes(s);
-    uint i;
-    result = 0;
-    for (i = 0; i < b.length; i++) {
-      uint c = uint(b[i]);
-      if (c >= 48 && c <= 57) {
-        result = result * 10 + (c - 48);
-      }
-    }
-  }
-
-
-  function __uintToBytes(uint x)
-  internal
-  pure
-  returns (bytes b)
-  {
-    b = new bytes(32);
-    for (uint i = 0; i < 32; i++) {
-      b[i] = byte(uint8(x / (2 ** (8 * (31 - i)))));
-    }
+    return checker.isUid(_uid);
   }
 
 }
@@ -517,7 +482,7 @@ contract TweedentityManager
 is Pausable, HasNoEther
 {
 
-  string public version = "1.3.0";
+  string public version = "1.5.0";
 
   struct Store {
     TweedentityStore store;
@@ -827,6 +792,7 @@ is Pausable, HasNoEther
 
     TweedentityStore _store = __getStore(_appId);
     require(_store.isUid(_uid));
+
     if (isUpgradable(_store, _address, _uid)) {
       _store.setIdentity(_address, _uid);
     } else {
@@ -881,41 +847,6 @@ is Pausable, HasNoEther
   onlyOwner
   {
     minimumTimeBeforeUpdate = _newMinimumTime;
-  }
-
-
-
-  // private methods
-
-
-  function __stringToUint(
-    string s
-  )
-  internal
-  pure
-  returns (uint result)
-  {
-    bytes memory b = bytes(s);
-    uint i;
-    result = 0;
-    for (i = 0; i < b.length; i++) {
-      uint c = uint(b[i]);
-      if (c >= 48 && c <= 57) {
-        result = result * 10 + (c - 48);
-      }
-    }
-  }
-
-
-  function __uintToBytes(uint x)
-  internal
-  pure
-  returns (bytes b)
-  {
-    b = new bytes(32);
-    for (uint i = 0; i < 32; i++) {
-      b[i] = byte(uint8(x / (2 ** (8 * (31 - i)))));
-    }
   }
 
 }

--- a/flattened/TweedentityStore-flattened.sol
+++ b/flattened/TweedentityStore-flattened.sol
@@ -155,7 +155,7 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet && checker != address(0));
+    require(appSet);
     _;
   }
 
@@ -236,6 +236,7 @@ is HasNoEther
   {
     require(!appSet);
     require(_appId > 0);
+    require(_checker != address(0));
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;

--- a/flattened/TweedentityStore-flattened.sol
+++ b/flattened/TweedentityStore-flattened.sol
@@ -83,6 +83,11 @@ contract HasNoEther is Ownable {
 
 // File: contracts/TweedentityStore.sol
 
+interface UidChecker {
+  function isUid(string _uid) public pure returns (bool);
+}
+
+
 /**
  * @title TweedentityStore
  * @author Francesco Sullo <francesco@sullo.co>
@@ -95,7 +100,7 @@ contract TweedentityStore
 is HasNoEther
 {
 
-  string public version = "1.3.0";
+  string public version = "1.5.0";
 
   uint public appId;
   string public appNickname;
@@ -104,6 +109,8 @@ is HasNoEther
 
   address public manager;
   address public newManager;
+
+  UidChecker public checker;
 
   struct Uid {
     string lastUid;
@@ -148,13 +155,28 @@ is HasNoEther
 
 
   modifier whenAppSet() {
-    require(appSet);
+    require(appSet && checker != address(0));
     _;
   }
 
 
 
   // config
+
+
+  /**
+  * @dev Updates the checker for the store
+  * @param _address Checker's address
+  */
+  function setNewChecker(
+    address _address
+  )
+  external
+  onlyOwner
+  {
+    require(_address != address(0));
+    checker = UidChecker(_address);
+  }
 
 
   /**
@@ -206,7 +228,8 @@ is HasNoEther
   */
   function setApp(
     string _appNickname,
-    uint _appId
+    uint _appId,
+    address _checker
   )
   external
   onlyOwner
@@ -216,6 +239,7 @@ is HasNoEther
     require(bytes(_appNickname).length > 0);
     appId = _appId;
     appNickname = _appNickname;
+    checker = UidChecker(_checker);
     appSet = true;
   }
 
@@ -341,20 +365,6 @@ is HasNoEther
 
 
   /**
-   * @dev Returns the user-id associated to a wallet as a unsigned integer
-   * @param _address The address of the wallet
-   */
-  function getUidAsInteger(
-    address _address
-  )
-  external
-  constant returns (uint)
-  {
-    return __stringToUint(__uidByAddress[_address].lastUid);
-  }
-
-
-  /**
    * @dev Returns the address associated to a user-id
    * @param _uid The user-id
    */
@@ -404,55 +414,10 @@ is HasNoEther
     string _uid
   )
   public
-  pure
+  view
   returns (bool)
   {
-    bytes memory uid = bytes(_uid);
-    if (uid.length == 0) {
-      return false;
-    } else {
-      for (uint i = 0; i < uid.length; i++) {
-        if (uid[i] < 48 || uid[i] > 57) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-
-
-  // private methods
-
-
-  function __stringToUint(
-    string s
-  )
-  internal
-  pure
-  returns (uint result)
-  {
-    bytes memory b = bytes(s);
-    uint i;
-    result = 0;
-    for (i = 0; i < b.length; i++) {
-      uint c = uint(b[i]);
-      if (c >= 48 && c <= 57) {
-        result = result * 10 + (c - 48);
-      }
-    }
-  }
-
-
-  function __uintToBytes(uint x)
-  internal
-  pure
-  returns (bytes b)
-  {
-    b = new bytes(32);
-    for (uint i = 0; i < 32; i++) {
-      b[i] = byte(uint8(x / (2 ** (8 * (31 - i)))));
-    }
+    return checker.isUid(_uid);
   }
 
 }

--- a/flattened/TwitterUidChecker-flattened.sol
+++ b/flattened/TwitterUidChecker-flattened.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.4.18;
+
+// File: contracts/TwitterUidChecker.sol
+
+/**
+ * @title TwitterUidChecker
+ * @author Francesco Sullo <francesco@sullo.co>
+ * @dev Checks if a uid is a Twitter uid
+ */
+
+
+
+contract TwitterUidChecker
+{
+
+  string public version = "1.5.0";
+
+  function isUid(
+    string _uid
+  )
+  public
+  pure
+  returns (bool)
+  {
+    bytes memory uid = bytes(_uid);
+    if (uid.length == 0 || uid.length > 20) {
+      return false;
+    } else {
+      for (uint i = 0; i < uid.length; i++) {
+        if (uid[i] < 48 || uid[i] > 57) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweedentity",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "tweedentity",
   "dependencies": {},
   "devDependencies": {

--- a/scripts/flatten.sh
+++ b/scripts/flatten.sh
@@ -3,6 +3,8 @@
 rm flattened/*
 
 contracts=(
+"TwitterUidChecker"
+"RedditUidChecker"
 "TweedentityStore"
 "TweedentityManager"
 "TweedentityClaimer"

--- a/test/RedditUidChecker-test.js
+++ b/test/RedditUidChecker-test.js
@@ -1,0 +1,27 @@
+
+const RedditUidChecker = artifacts.require('./RedditUidChecker.sol')
+
+contract('RedditUidChecker', accounts => {
+
+  let checker
+
+  async function getValue(what) {
+    return (await store[what]()).valueOf()
+  }
+
+  before(async () => {
+    checker = await RedditUidChecker.new()
+  })
+
+  it('should check the integrity of the uids', async () => {
+    assert.isTrue(await checker.isUid('aabcdefghi_--'))
+    assert.isTrue(await checker.isUid('____----___'))
+    assert.isTrue(await checker.isUid('123'))
+    // even if Reddit uses lower and upper case, the store accepts only lowercase
+    assert.isFalse(await checker.isUid('UPPERcase'))
+    assert.isFalse(await checker.isUid('asadsad['))
+    assert.isFalse(await checker.isUid('__')) // too short
+    assert.isFalse(await checker.isUid('abs___-trgdtegrtdget_')) // too long
+  })
+
+})

--- a/test/TweedentityClaimer-test.js
+++ b/test/TweedentityClaimer-test.js
@@ -1,6 +1,7 @@
 const assertRevert = require('./helpers/assertRevert')
 const eventWatcher = require('./helpers/EventWatcher')
 
+const TwitterUidChecker = artifacts.require('./TwitterUidChecker.sol')
 const TweedentityStore = artifacts.require('./TweedentityStore.sol')
 const TweedentityManager = artifacts.require('./TweedentityManager.sol')
 const TweedentityClaimer = artifacts.require('./TweedentityClaimer.sol')
@@ -22,6 +23,7 @@ function logValue(...x) {
 
 contract('TweedentityClaimer', accounts => {
 
+  let twitterChecker
   let manager
   let store
   let claimer
@@ -32,12 +34,13 @@ contract('TweedentityClaimer', accounts => {
   let appId = 1
 
   before(async () => {
+    twitterChecker = await TwitterUidChecker.new()
     store = await TweedentityStore.new()
     manager = await TweedentityManager.new()
     claimer = await TweedentityClaimer.new()
 
     await store.setManager(manager.address)
-    await store.setApp(appNickname, appId)
+    await store.setApp(appNickname, appId, twitterChecker.address)
     await manager.setAStore(appNickname, store.address)
 
     wait = (new Wait(await Counter.new())).wait
@@ -94,7 +97,7 @@ contract('TweedentityClaimer', accounts => {
 
 
     const gasPrice = 4e9
-    const gasLimit = 17e4
+    const gasLimit = 18e4
 
     await claimer.claimOwnership(
       appNickname,

--- a/test/TweedentityRegistry-test.js
+++ b/test/TweedentityRegistry-test.js
@@ -1,3 +1,5 @@
+const TwitterUidChecker = artifacts.require('./TwitterUidChecker.sol')
+const RedditUidChecker = artifacts.require('./RedditUidChecker.sol')
 const TweedentityStore = artifacts.require('./TweedentityStore.sol')
 const TweedentityManager = artifacts.require('./TweedentityManager.sol')
 const TweedentityClaimer = artifacts.require('./TweedentityClaimer.sol')
@@ -7,24 +9,29 @@ const TweedentityRegistry = artifacts.require('./TweedentityRegistry.sol')
 contract('TweedentityRegistry', accounts => {
 
   let manager
+  let twitterChecker
+  let redditChecker
   let twitterStore
-  let githubStore
+  let redditStore
   let claimer
   let registry
 
   before(async () => {
+    twitterChecker = await TwitterUidChecker.new()
+    redditChecker = await RedditUidChecker.new()
+
     twitterStore = await TweedentityStore.new()
-    githubStore = await TweedentityStore.new()
+    redditStore = await TweedentityStore.new()
     manager = await TweedentityManager.new()
     claimer = await TweedentityClaimer.new()
 
     await twitterStore.setManager(manager.address)
-    await twitterStore.setApp('twitter', 1)
+    await twitterStore.setApp('twitter', 1, twitterChecker.address)
     await manager.setAStore('twitter', twitterStore.address)
 
-    await githubStore.setManager(manager.address)
-    await githubStore.setApp('github', 2)
-    await manager.setAStore('github', githubStore.address)
+    await redditStore.setManager(manager.address)
+    await redditStore.setApp('reddit', 2, redditChecker.address)
+    await manager.setAStore('reddit', redditStore.address)
 
     await manager.setClaimer(claimer.address)
   })
@@ -40,8 +47,8 @@ contract('TweedentityRegistry', accounts => {
   })
 
   it('should set the store for Github', async () => {
-    await registry.setAStore('github', githubStore.address)
-    assert.equal(await registry.getStore('github'), githubStore.address)
+    await registry.setAStore('reddit', redditStore.address)
+    assert.equal(await registry.getStore('reddit'), redditStore.address)
   })
 
   it('should set the manager', async () => {
@@ -62,21 +69,21 @@ contract('TweedentityRegistry', accounts => {
 
   it('should set all and be ready', async() => {
     await registry.setAStore('twitter', twitterStore.address)
-    await registry.setAStore('github', githubStore.address)
+    await registry.setAStore('reddit', redditStore.address)
     await registry.setManagerAndClaimer(manager.address, claimer.address)
     assert.isTrue(await registry.isReady())
   })
 
   it('should set all and be ready', async() => {
     await registry.setAStore('twitter', twitterStore.address)
-    await registry.setAStore('github', githubStore.address)
+    await registry.setAStore('reddit', redditStore.address)
     await registry.setManagerAndClaimer(manager.address, claimer.address)
     assert.isTrue(await registry.isReady())
   })
 
   it('should set all but be not ready because manager is paused', async() => {
     await registry.setAStore('twitter', twitterStore.address)
-    await registry.setAStore('github', githubStore.address)
+    await registry.setAStore('reddit', redditStore.address)
     await registry.setManagerAndClaimer(manager.address, claimer.address)
     await manager.pause()
     assert.isFalse(await registry.isReady())

--- a/test/TweedentityStore-test.js
+++ b/test/TweedentityStore-test.js
@@ -3,6 +3,8 @@ const assertRevert = require('./helpers/assertRevert')
 
 const eventWatcher = require('./helpers/EventWatcher')
 
+const TwitterUidChecker = artifacts.require('./TwitterUidChecker.sol')
+const RedditUidChecker = artifacts.require('./RedditUidChecker.sol')
 const TweedentityStore = artifacts.require('./TweedentityStore.sol')
 const TweedentityStoreCaller = artifacts.require('./helpers/TweedentityStoreCaller')
 
@@ -15,8 +17,11 @@ function now() {
 
 contract('TweedentityStore', accounts => {
 
-  let store
+  let twitterStore
   let storeCaller
+  let twitterChecker
+  let redditStore
+  let redditChecker
 
   let manager = accounts[1]
   let bob = accounts[3]
@@ -30,110 +35,129 @@ contract('TweedentityStore', accounts => {
   let wait
 
   async function getValue(what) {
-    return (await store[what]()).valueOf()
+    return (await twitterStore[what]()).valueOf()
   }
 
   before(async () => {
-    store = await TweedentityStore.new()
+    twitterChecker = await TwitterUidChecker.new()
+    redditChecker = await RedditUidChecker.new()
+    twitterStore = await TweedentityStore.new()
+    redditStore = await TweedentityStore.new()
     storeCaller = await TweedentityStoreCaller.new()
-    await storeCaller.setStore(store.address)
+    await storeCaller.setStore(twitterStore.address)
     wait = (new Wait(await Counter.new())).wait
   })
 
   it('should be empty', async () => {
-    assert.equal(await store.identities(), 0)
+    assert.equal(await twitterStore.identities(), 0)
   })
 
   it('should revert trying to add a new tweedentity', async () => {
-    await assertRevert(store.setIdentity(rita, id1))
+    await assertRevert(twitterStore.setIdentity(rita, id1))
   })
 
   it('should authorize manager to handle the data', async () => {
-    await store.setManager(manager)
-    assert.equal((await store.manager()), manager)
+    await twitterStore.setManager(manager)
+    assert.equal((await twitterStore.manager()), manager)
   })
 
   it('should revert trying to add a new tweedentity because the store is not declared', async () => {
-    await assertRevert(store.setIdentity(rita, id1))
+    await assertRevert(twitterStore.setIdentity(rita, id1))
   })
 
   it('should declare the store', async () => {
-    await store.setApp('twitter', 1)
-    assert.equal(await store.getAppNickname(), web3.sha3('twitter'))
-    assert.equal(await store.getAppId(), 1)
+    await twitterStore.setApp('twitter', 1, twitterChecker.address)
+    assert.equal(await twitterStore.getAppNickname(), web3.sha3('twitter'))
+    assert.equal(await twitterStore.getAppId(), 1)
   })
 
   it('should add a new identity with uid id1 for rita', async () => {
-    assert.equal(await store.getAddress(id1), 0)
+    assert.equal(await twitterStore.getAddress(id1), 0)
 
-    await store.setIdentity(rita, id1, {from: manager})
-    assert.equal(await store.getAddress(id1), rita)
-    assert.equal(await store.getUid(rita), id1)
-    assert.equal(await store.identities(), 1)
+    await twitterStore.setIdentity(rita, id1, {from: manager})
+    assert.equal(await twitterStore.getAddress(id1), rita)
+    assert.equal(await twitterStore.getUid(rita), id1)
+    assert.equal(await twitterStore.identities(), 1)
   })
 
   it('should revert trying to associate accounts[5] to uid id3 using a not authorized owner', async () => {
-    await assertRevert(store.setIdentity(accounts[5], id3))
+    await assertRevert(twitterStore.setIdentity(accounts[5], id3))
   })
 
   it('should revert trying to associate bob with id1 since this is associated w/ rita', async () => {
-    await assertRevert(store.setIdentity(bob, id1, {from: manager}))
+    await assertRevert(twitterStore.setIdentity(bob, id1, {from: manager}))
   })
 
   it('should not revert trying to associate again id1 to rita', async () => {
-    const lastUpdate = await store.getAddressLastUpdate(rita)
+    const lastUpdate = await twitterStore.getAddressLastUpdate(rita)
     wait()
-    await store.setIdentity(rita, id1, {from: manager})
-    assert.isTrue(await store.getAddressLastUpdate(rita) != lastUpdate)
+    await twitterStore.setIdentity(rita, id1, {from: manager})
+    assert.isTrue(await twitterStore.getAddressLastUpdate(rita) != lastUpdate)
   })
 
   it('should associate now rita with the uid id2 and reverse after 1 second', async () => {
-    await store.setIdentity(rita, id2, {from: manager})
-    assert.equal(await store.identities(), 1)
-    assert.equal(await store.getUid(rita), id2)
+    await twitterStore.setIdentity(rita, id2, {from: manager})
+    assert.equal(await twitterStore.identities(), 1)
+    assert.equal(await twitterStore.getUid(rita), id2)
 
-    await store.setIdentity(rita, id1, {from: manager})
-    assert.equal(await store.identities(), 1)
-    assert.equal(await store.getUid(rita), id1)
+    await twitterStore.setIdentity(rita, id1, {from: manager})
+    assert.equal(await twitterStore.identities(), 1)
+    assert.equal(await twitterStore.getUid(rita), id1)
   })
 
   it('should associate id2 to alice', async () => {
-    await store.setIdentity(alice, id2, {from: manager})
-    assert.equal(await store.identities(), 2)
+    await twitterStore.setIdentity(alice, id2, {from: manager})
+    assert.equal(await twitterStore.identities(), 2)
   })
 
   it('should return rita if searching for id1 and viceversa', async () => {
-    assert.equal(await store.getAddress(id1), rita)
-    assert.equal(await store.getUid(rita), id1)
+    assert.equal(await twitterStore.getAddress(id1), rita)
+    assert.equal(await twitterStore.getUid(rita), id1)
   })
 
   it('should allow manager to remove the identity for rita', async () => {
 
-    assert.notEqual(await store.getUid(rita), 0)
-    await store.unsetIdentity(rita, {from: manager})
-    assert.equal(await store.getUid(rita), '')
+    assert.notEqual(await twitterStore.getUid(rita), 0)
+    await twitterStore.unsetIdentity(rita, {from: manager})
+    assert.equal(await twitterStore.getUid(rita), '')
 
   })
 
   it('should allow bob to be associated to id1', async () => {
 
-    await store.setIdentity(bob, id1, {from: manager})
+    await twitterStore.setIdentity(bob, id1, {from: manager})
 
-    assert.equal(await store.getUid(rita), 0)
-    assert.equal(await store.getUid(bob), id1)
-    assert.equal(await store.getAddress(id1), bob)
+    assert.equal(await twitterStore.getUid(rita), 0)
+    assert.equal(await twitterStore.getUid(bob), id1)
+    assert.equal(await twitterStore.getAddress(id1), bob)
 
   })
 
   it('should verify that all the function callable from other contracts are actually callable', async () => {
 
     assert.equal(await storeCaller.getAddress(id1), bob)
-    assert.equal(await storeCaller.getUidAsInteger(bob), 12345)
-    assert.equal(await storeCaller.getAddress(id1), bob)
-    assert.equal(await storeCaller.getAddressLastUpdate(bob), (await store.getAddressLastUpdate(bob)).valueOf())
-    assert.equal(await storeCaller.getUidLastUpdate(id1), (await store.getUidLastUpdate(id1)).valueOf())
+    assert.equal(await storeCaller.getAddressLastUpdate(bob), (await twitterStore.getAddressLastUpdate(bob)).valueOf())
+    assert.equal(await storeCaller.getUidLastUpdate(id1), (await twitterStore.getUidLastUpdate(id1)).valueOf())
   })
 
+  it('should authorize manager to handle the reddit store', async () => {
+    await redditStore.setManager(manager)
+    assert.equal((await redditStore.manager()), manager)
+  })
 
+  it('should declare the reddit store', async () => {
+    await redditStore.setApp('reddit', 2, redditChecker.address)
+    assert.equal(await redditStore.getAppNickname(), web3.sha3('reddit'))
+    assert.equal(await redditStore.getAppId(), 2)
+  })
+
+  it('should add a new identity with uid id1 for rita', async () => {
+    assert.equal(await redditStore.getAddress(id1), 0)
+
+    await redditStore.setIdentity(rita, id1, {from: manager})
+    assert.equal(await redditStore.getAddress(id1), rita)
+    assert.equal(await redditStore.getUid(rita), id1)
+    assert.equal(await redditStore.identities(), 1)
+  })
 
 })

--- a/test/TwitterUidChecker-test.js
+++ b/test/TwitterUidChecker-test.js
@@ -1,0 +1,24 @@
+
+const TwitterUidChecker = artifacts.require('./TwitterUidChecker.sol')
+
+contract('TwitterUidChecker', accounts => {
+
+  let checker
+
+  async function getValue(what) {
+    return (await store[what]()).valueOf()
+  }
+
+  before(async () => {
+    checker = await TwitterUidChecker.new()
+  })
+
+  it('should check the integrity of the uids', async () => {
+    assert.isTrue(await checker.isUid('6924928'))
+    assert.isTrue(await checker.isUid('9812635291969249283'))
+    assert.isFalse(await checker.isUid('239812635291969249282')) // too long
+    assert.isFalse(await checker.isUid(''))
+    assert.isFalse(await checker.isUid('8963746asa'))
+  })
+
+})


### PR DESCRIPTION
Separate the integrity checker `isUid` from the store in order to generalize the store.