### PR TITLE
Renaming the method to avoid a weird issue with web3

### DIFF
--- a/contracts/TweedentityClaimer.sol
+++ b/contracts/TweedentityClaimer.sol
@@ -90,7 +90,7 @@ is usingOraclize, HasNoEther
    * @param _gasPrice The gas price for Oraclize
    * @param _gasLimit The gas limit for Oraclize
    */
-  function claimOwnership(
+  function claimAccountOwnership(
     string _appNickname,
     string _postId,
     uint _gasPrice,

--- a/flattened/TweedentityClaimer-flattened.sol
+++ b/flattened/TweedentityClaimer-flattened.sol
@@ -2158,7 +2158,7 @@ is usingOraclize, HasNoEther
    * @param _gasPrice The gas price for Oraclize
    * @param _gasLimit The gas limit for Oraclize
    */
-  function claimOwnership(
+  function claimAccountOwnership(
     string _appNickname,
     string _postId,
     uint _gasPrice,

--- a/test/TweedentityClaimer-test.js
+++ b/test/TweedentityClaimer-test.js
@@ -58,7 +58,7 @@ contract('TweedentityClaimer', accounts => {
     const gasLimit = 30e4
 
     await assertRevert(
-      claimer.claimOwnership(
+      claimer.claimAccountOwnership(
         appNickname,
         tweet.id,
         gasPrice,
@@ -81,7 +81,7 @@ contract('TweedentityClaimer', accounts => {
     const gasPrice = 4e9
     const gasLimit = 20e4
 
-    await assertRevert(claimer.claimOwnership(
+    await assertRevert(claimer.claimAccountOwnership(
       appNickname,
       '',
       21e9,
@@ -99,7 +99,7 @@ contract('TweedentityClaimer', accounts => {
     const gasPrice = 4e9
     const gasLimit = 18e4
 
-    await claimer.claimOwnership(
+    await claimer.claimAccountOwnership(
       appNickname,
       tweet.id,
       gasPrice,
@@ -138,7 +138,7 @@ contract('TweedentityClaimer', accounts => {
     const gasPrice = 4e9
     const gasLimit = 17e4
 
-    await claimer.claimOwnership(
+    await claimer.claimAccountOwnership(
       appNickname,
       tweet.id,
       gasPrice,


### PR DESCRIPTION
During the test, for some reason, Etherscan, when the `claimOwnership` was called was reporting a wrong parameter (taken from a previous version of the claimer). To solve it here the method is renamed to `claimAccounOwnership`.